### PR TITLE
added deps back to dockerfile - fixes crashing image issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=0 /app/megaqc/static/ /app/megaqc/static/
 
 RUN pip install --upgrade pip
 RUN pip install sqlalchemy==1.3.24
-RUN pip install flask-sqlalchemy
+RUN pip install flask-sqlalchemy==2.5.1
 RUN pip install marshmallow-sqlalchemy==0.25
 
 RUN pip install /app[prod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,9 @@ COPY . /app
 # Copy the compiled JS in from the other node container
 COPY --from=0 /app/megaqc/static/ /app/megaqc/static/
 
+RUN pip install --upgrade pip
+RUN pip install sqlalchemy==1.3.24
+RUN pip install flask-sqlalchemy
+RUN pip install marshmallow-sqlalchemy==0.25
+
 RUN pip install /app[prod]


### PR DESCRIPTION

this fixes the 13 second crashing issue - I added the sqlalchemy related dependencies back into the dockerfile. I tried them all individually but none saved the issue alone so I added them all back in as there are too many combinations to try to get the most minimal solution (or maybe all are required).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/megaqc/2)
<!-- Reviewable:end -->
